### PR TITLE
Added keepAlive refresh mode & bugfixes

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+    "printWidth": 100,
+    "parser": "flow",
+    "tabWidth": 4,
+    "singleQuote": false
+  }

--- a/README.md
+++ b/README.md
@@ -70,4 +70,4 @@ Password=> :1:2345678910:ABCDEFGHIJKLMNOP <= Yes, all this string.
 The refresh mode could be one of:
 - none - no auto refresh, we will connect to roomba and poll status when requested by home app. please note that this will cause "Updating" status for all homebridge accessories.
 - autoRefresh - we will connect to roomba, every `pollingInterval` seconds, and store the status in cache. if pollingInterval = cacheTTL - 10 (or more), this will make sure we will always have a valid status.
-- keepAlive - we will keep a connection to roomba, this will cause app to fail to connect to roomba in local network mode (cloud mode will work just fine, even in your home wifi).
+- keepAlive - we will keep a connection to roomba, this will cause app to fail to connect to roomba in local network mode (cloud mode will work just fine, even in your home wifi). this will lead to better performance (status will refresh faster, and toggle will work faster as well)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ https://github.com/steedferns/homebridge-roomba980
 
 https://github.com/gbro115/homebridge-roomba690
 
+ [@matanelgabsi](https://github.com/matanelgabsi) for keepAlive feature
+
 ## Installation:
 
 ### 1. Install homebridge and Roomba plugin.

--- a/README.md
+++ b/README.md
@@ -57,9 +57,15 @@ Password=> :1:2345678910:ABCDEFGHIJKLMNOP <= Yes, all this string.
     "blid": "1234567890",
     "robotpwd": "aPassword",
     "ipaddress": "10.0.0.30",
-    "autoRefreshEnabled" : true //optional
-    "pollingInterval" : 30, //in seconds
-    "cacheTTL" : 30 //in seconds
+    "refreshMode": "keepAlive", //If you use local network mode in roomba app, consider using other values. see note below
+    "pollingInterval": 30, //in seconds
+    "cacheTTL": 30 //in seconds
   }
 ]
 ```
+
+#### refreshMode
+The refresh mode could be one of:
+- none - no auto refresh, we will connect to roomba and poll status when requested by home app. please note that this will cause "Updating" status for all homebridge accessories.
+- autoRefresh - we will connect to roomba, every `pollingInterval` seconds, and store the status in cache. if pollingInterval = cacheTTL - 10 (or more), this will make sure we will always have a valid status.
+- keepAlive - we will keep a connection to roomba, this will cause app to fail to connect to roomba in local network mode (cloud mode will work just fine, even in your home wifi).

--- a/index.js
+++ b/index.js
@@ -199,7 +199,6 @@ roombaAccessory.prototype = {
 
     getStatus(callback, silent) {
         let status = this.cache.get(STATUS);
-        this.log("status" + JSON.stringify(status));
         if (status) {
             callback(null, status);
         } else {
@@ -237,7 +236,6 @@ roombaAccessory.prototype = {
     },
 
     parseState(state) {
-        this.log("Parsing");
         let status = {
             running: 0,
             charging: 0,
@@ -253,7 +251,6 @@ roombaAccessory.prototype = {
         } else {
             status.batteryStatus = Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL;
         }
-        this.log("mission: ", state.cleanMissionStatus);
         switch (state.cleanMissionStatus.phase) {
             case "run":
                 status.running = 1;
@@ -309,7 +306,6 @@ roombaAccessory.prototype = {
         });
     },
     autoRefresh() {
-        this.log("auto refresh " + this.autoRefreshEnabled + " " + this.pollingInterval);
         if (this.autoRefreshEnabled) {
             clearTimeout(this.timer);
 

--- a/index.js
+++ b/index.js
@@ -15,8 +15,8 @@ const roombaAccessory = function(log, config) {
     this.ipaddress = config.ipaddress;
     this.firmware = "N/A";
     this.autoRefreshEnabled = config.autoRefreshEnabled | true;
-    this.pollingInterval = config.pollingInterval | 60;
-    this.cacheTTL = config.cacheTTL | 30;
+    this.pollingInterval = config.pollingInterval || 60;
+    this.cacheTTL = config.cacheTTL || 30;
 
     this.accessoryInfo = new Service.AccessoryInformation();
     this.switchService = new Service.Switch(this.name);


### PR DESCRIPTION
Hi there!
Great plugin, using it for a few days and loved it.
Unfortunately, when I started using it, I noticed that my Home app marks my accessories as "updating" all the time :(

I looked at the code, and found 2 issues:
1. There was a binary or (|) instead of an logical or (||)
2. When the current status was fetching, the status was inaccessible (was changed to "fetching"), this led to a few seconds (around 8 in my case) when the app would hand, as it was waiting for a status. if my polling interval was around 40S, this will cause the app to hand about 1/4 of the time... A better approach would be to use the last status always, even if we are currently updating..

In addition to fixing this bugs, I added a new mode: keepAlive. This keeps the connection to Roomba alive, and updates the status when Roomba posts updated, without any delay.

Also changed the docs to reflect all those change.

I would greatly appreciate if you could review this changes and merge them. Thanks!