### PR TITLE
Fix “ReferenceError: dockWhenStopped is not defined”

### DIFF
--- a/index.js
+++ b/index.js
@@ -126,7 +126,7 @@ roombaAccessory.prototype = {
                     break;
                 case "run":
                     this.log("Roomba is still running. Will check again in 3 seconds");
-                    dockWhenStopped(roomba, pollingInterval);
+                    this.dockWhenStopped(roomba, pollingInterval);
 
                     break;
                 default:


### PR DESCRIPTION
Fixes this error:
```
homebridge[2354]: [2018-10-21 02:33:57] [Roomba] ReferenceError: dockWhenStopped is not defined
homebridge[2354]:     at roombaAccessory.dockWhenStopped (/home/pi/.npm-global/lib/node_modules/homebridge-roomba-stv/index.js:129:21)
```